### PR TITLE
Fix manifest.json

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -5,7 +5,7 @@
             "src": "images/android-touch-icon-192x192.png",
             "sizes": "192x192",
             "type": "image/png",
-            "density": "4.0"
+            "density": 4.0
         }
     ],
     "start_url": "index.html",


### PR DESCRIPTION
Came across this via [Opera's PWA list](https://operasoftware.github.io/pwa-list/).

Noticed an issue with your icon's density. Apparently this has to be a float instead of a string, for browsers to parse it properly. Chrome logs the following error:

> Manifest parsing error: icon 'density' ignored, must be float greater than 0.
